### PR TITLE
[Issue #1] Application crashes (immediately) after choosing ' View log' from the menu.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation 'io.reactivex.rxjava3:rxandroid:3.0.2'
     implementation 'io.reactivex.rxjava3:rxjava:3.1.5'
 
-    implementation "org.ocpsoft.prettytime:prettytime:5.0.6.Final"
+    implementation "org.ocpsoft.prettytime:prettytime:4.0.6.Final"
     implementation "dnsjava:dnsjava:3.5.2"
 
 }


### PR DESCRIPTION
Changed the required version to org.ocpsoft.prettytime:prettytime to 4.0.6.Final (as per the library documentation). This should be compatible with all the target OS versions.