### PR TITLE
[Issue #3] Bug in the implementation of Api.getPackagesForUser() le…

### DIFF
--- a/app/src/main/java/dev/ukanth/ufirewall/Api.java
+++ b/app/src/main/java/dev/ukanth/ufirewall/Api.java
@@ -1688,7 +1688,7 @@ public final class Api {
     public static HashMap<Integer, String> getPackagesForUser(List<Integer> userProfile) {
         HashMap<Integer,String> listApps = new HashMap<>();
         for(Integer integer: userProfile) {
-            Shell.Result result = Shell.cmd("pm list packages -U --user " + integer).exec();
+            Shell.Result result = Shell.cmd("pm list packages -u --user " + integer).exec();
             List<String> out = result.getOut();
             Matcher matcher;
             for (String item : out) {


### PR DESCRIPTION
…ading to empty package list.

Fixed the error in the syntax of the 'pm list packages' command executed in the Api.getPackagesForUser() leading to an execution error and consequently to an empty package list getting returned.